### PR TITLE
Some changes to prepare for Polymer 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,18 +20,18 @@
     "/tests/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
-    "paper-material": "PolymerElements/paper-material#^1.0.0"
+    "polymer": "Polymer/polymer#^1.9.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^2.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0",
+    "paper-material": "PolymerElements/paper-material#^2.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
-    "paper-toast": "PolymerElements/paper-toast#^1.0.0",
-    "paper-input": "PolymerElements/paper-input#~1.1.3",
-    "iron-input": "PolymerElements/iron-input#~1.0.7",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#~1.0.2"
+    "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^2.0.0",
+    "paper-toast": "PolymerElements/paper-toast#^2.0.0",
+    "paper-input": "PolymerElements/paper-input#^2.0.0",
+    "iron-input": "PolymerElements/iron-input#^2.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,6 +16,7 @@
   <link rel="import" href="../../paper-toast/paper-toast.html">
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="../../iron-icon/iron-icon.html">
   <link rel="import" href="avatars.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">
@@ -45,9 +46,9 @@
   <demo-snippet>
     <template>
       <paper-chip removable>
-        <iron-icon class="icon" icon="avatars:avatar-1"></iron-icon>
-        <div class="label">John Doe</div>
-        <div class="caption">doeboy@example.com</div>
+        <iron-icon slot="icon" class="icon" icon="avatars:avatar-1"></iron-icon>
+        <div slot="label">John Doe</div>
+        <div slot="caption">doeboy@example.com</div>
       </paper-chip>
     </template>
     <paper-toast id="toast1" text="John Doe was removed!"></paper-toast>
@@ -57,9 +58,9 @@
   <demo-snippet>
     <template>
       <paper-chip removable animated>
-        <iron-icon class="icon" icon="avatars:avatar-1"></iron-icon>
-        <div class="label">John Doe</div>
-        <div class="caption">doeboy@example.com</div>
+        <iron-icon slot="icon" class="icon" icon="avatars:avatar-1"></iron-icon>
+        <div slot="label">John Doe</div>
+        <div slot="caption">doeboy@example.com</div>
       </paper-chip>
     </template>
     <paper-toast text="John Doe was removed!"></paper-toast>
@@ -69,9 +70,9 @@
   <demo-snippet>
     <template>
       <paper-chip removable animated>
-        <iron-icon class="icon" icon="avatars:avatar-13"></iron-icon>
-        <div class="label">Jane Doe</div>
-        <div class="caption">janedoe@example.com</div>
+        <iron-icon slot="icon" class="icon" icon="avatars:avatar-13"></iron-icon>
+        <div slot="label">Jane Doe</div>
+        <div slot="caption">janedoe@example.com</div>
         <address>
           123 Avenue Way<br>
           Anytown, USA 12345<br>
@@ -86,9 +87,9 @@
   <demo-snippet>
     <template>
       <paper-chip>
-        <div class="icon">P</div>
-        <div class="label">Peter Parker</div>
-        <div class="caption">pete@dailybugle.com</div>
+        <div slot="icon" class="icon">P</div>
+        <div slot="label">Peter Parker</div>
+        <div slot="caption">pete@dailybugle.com</div>
       </paper-chip>
     </template>
   </demo-snippet>
@@ -97,7 +98,7 @@
   <demo-snippet>
     <template>
       <paper-chip removable single-line>
-        <div class="label">Example Chip</div>
+        <div slot="label">Example Chip</div>
       </paper-chip>
     </template>
   </demo-snippet>
@@ -107,13 +108,13 @@
     <template>
       <template is="dom-bind" id="chipInputDemo">
         <paper-input-container id="tags">
-          <label>Tags</label>
+          <label slot="label">Tags</label>
           <!-- a hidden iron-input holds the bind-value value for paper-input-container -->
-          <input is="iron-input" type="hidden" bind-value="{{tagsString}}">
-          <div class="tags-input layout horizontal wrap">
+          <iron-input><input is="iron-input" type="hidden" bind-value="{{tagsString}}" slot="input"></iron-input>
+          <div class="tags-input layout horizontal wrap" slot="input">
             <template is="dom-repeat" items="{{tags}}">
               <paper-chip removable single-line>
-                <span class="label">{{item}}</span>
+                <span slot="label">{{item}}</span>
               </paper-chip>
             </template>
             <input id="tagInput" type="text" class="flex">

--- a/paper-chip.html
+++ b/paper-chip.html
@@ -15,13 +15,13 @@ its closed state, it contains an icon and a short title. In its open state, the
 chip expands to show more detail about the represented entity, as well as
 (optionally) a "remove" button that removes the chip element from the DOM.
 
-The following child elements may be placed within the chip tag define its
-content:
+The child elements with the following slots be placed within the paper-chip tag
+to define its content:
 
-  * .icon: The icon representing the chip. This may be any element, for
+  * icon: The icon representing the chip. This may be any element, for
             example, a `<iron-icon>` or a simple `<span>` with a single letter
-  * .label: The chip label, shown in both closed and opened states
-  * .caption: A secondary label, shown only in the opened state
+  * label: The chip label, shown in both closed and opened states
+  * caption: A secondary label, shown only in the opened state
   * all other content will be shown in the opened chip
 
 The `removable` attribute can be used to add a button which removes the chip
@@ -32,7 +32,7 @@ from the DOM.
 Removable chip with iron-icon
 
     <paper-chip removable>
-      <iron-icon class="icon" icon="avatars:avatar-1"></iron-icon>
+      <iron-icon slot="icon" icon="avatars:avatar-1"></iron-icon>
       <div slot="label">John Doe</div>
       <div slot="caption">jdoe@example.com</div>
     </paper-chip>
@@ -64,7 +64,7 @@ Basic chip with single letter instead of an icon
         margin: 8px 0;
         height: 32px;
         overflow: visible;
-        @apply(--paper-chip);
+        @apply --paper-chip;
       }
       :host([animated]) *,
       :host([animated]) ::slotted(*) {
@@ -77,21 +77,21 @@ Basic chip with single letter instead of an icon
         background-color: var(--paper-chip-background-color, --paper-grey-200);
         position: relative;
         color: var(--paper-chip-secondary-text-color, --secondary-text-color);
-        @apply(--layout-vertical);
+        @apply --layout-vertical;
       }
       #chip {
         box-sizing: border-box;
         height: 32px;
-        @apply(--layout-horizontal);
-        @apply(--layout-center);
+        @apply --layout-horizontal;
+        @apply --layout-center;
       }
       paper-material {
         border-radius: 16px;
       }
       #icon {
-        @apply(--layout-horizontal);
-        @apply(--layout-center);
-        @apply(--layout-center-justified);
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
       }
       #icon ::slotted([slot=icon]) {
         margin-right: -4px;
@@ -106,7 +106,7 @@ Basic chip with single letter instead of an icon
         font-weight: bold;
         background-color: var(--paper-chip-icon-background-color, --paper-grey-500);
         color: var(--paper-chip-icon-text-color, --text-primary-color);
-        @apply(--layout-flex);
+        @apply --layout-flex;
       }
       #icon ::slotted(iron-icon.icon),
       #icon ::slotted(iron-icon.icon svg) { /* FIXME: only top-level selectors allowed */
@@ -118,8 +118,8 @@ Basic chip with single letter instead of an icon
       }
       #label {
         padding: 0 4px 0 12px;
-        @apply(--layout-flex-auto);
-        @apply(--layout-self-center);
+        @apply --layout-flex-auto;
+        @apply --layout-self-center;
       }
       :host([single-line]:not([removable])) #label {
         padding-right: 12px;
@@ -133,13 +133,13 @@ Basic chip with single letter instead of an icon
         font-size: 14px;
       }
       #label ::slotted([slot=label]) {
-        @apply(--paper-chip-label);
+        @apply --paper-chip-label;
       }
       #label ::slotted([slot=caption]) {
-        @apply(--paper-chip-caption);
+        @apply --paper-chip-caption;
       }
       .icon-btn-wrapper {
-        @apply(--layout-self-center);
+        @apply --layout-self-center;
       }
       #removeBtn {
         position: relative;
@@ -151,13 +151,13 @@ Basic chip with single letter instead of an icon
         background-color: var(--paper-chip-removebtn-background-color, --paper-grey-400);
         color: var(--paper-chip-removebtn-icon-color, --text-primary-color);
         cursor: pointer;
-        @apply(--paper-chip-removebtn);
+        @apply --paper-chip-removebtn;
       }
       #removeBtn iron-icon {
         width: 12px;
         height: 12px;
         display: block;
-        @apply(--paper-chip-removebtn-icon);
+        @apply --paper-chip-removebtn-icon;
       }
       :host(:not([removable])) #removeBtn {
         display: none;
@@ -202,7 +202,7 @@ Basic chip with single letter instead of an icon
         width: auto;
         min-width: 100%;
         overflow: hidden;
-        @apply(--paper-chip-content);
+        @apply --paper-chip-content;
       }
       :host([opened]) #chip {
         height: 72px;
@@ -215,7 +215,7 @@ Basic chip with single letter instead of an icon
       :host([opened]) #label ::slotted([slot=label]) {
         color: var(--paper-chip-primary-text-color, --primary-text-color);
         font-size: 16px;
-        @apply(--paper-chip-label-opened);
+        @apply --paper-chip-label-opened;
       }
       :host([opened]) paper-material {
         border-radius: 0;


### PR DESCRIPTION
- updated dependencies to the hybrid Polymer 2.0 versions
- fixed @apply syntax in style to no longer use the deprecated `@apply(--foo)` syntax, instead using `@apply --foo`.
- updated the demo page to use slots
- updated element documentation to mention slots instead of classes

The final demo still isn't working, something's up with the paper-input-container I think, but this PR does get the other demos working again.